### PR TITLE
get first item response from array in previewer

### DIFF
--- a/controller/ItemResultPreviewer.php
+++ b/controller/ItemResultPreviewer.php
@@ -100,7 +100,7 @@ class ItemResultPreviewer extends ToolModule
             $this->defaultData();
             $data['type'] = $this->getItemResultPreviewerType($resultIdentifier);
             $data['content'] = $this->getItemContent($itemDefinition, $resultIdentifier, $delivery->getUri());
-            $data['state'] = $this->getItemResultVariables($delivery, $resultIdentifier, $itemDefinition);;
+            $data['state'] = current($this->getItemResultVariables($delivery, $resultIdentifier, $itemDefinition));
             $data['itemDefinition'] = $itemDefinition;
             $data['resultIdentifier'] = $resultIdentifier;
             $data['deliveryIdentifier'] = $delivery->getUri();

--- a/manifest.php
+++ b/manifest.php
@@ -4,16 +4,16 @@
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
@@ -25,7 +25,7 @@ return array(
     'label' => 'LTI Result Tool Provider',
     'description' => 'The LTI Result Tool Provider allows third party applications to view results created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '0.1.0',
+    'version' => '0.1.1',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoLti' => '>=6.3.3',
@@ -50,19 +50,19 @@ return array(
         array('grant', LtiRoles::CONTEXT_INSTRUCTOR, array('ext'=>'ltiOutcomeUi', 'mod' => 'ItemResultPreviewer')),
     ),
     'constants' => array(
-    
+
         # views directory
         "DIR_VIEWS"                => __DIR__.DIRECTORY_SEPARATOR."views".DIRECTORY_SEPARATOR,
-    
+
         # default module name
         'DEFAULT_MODULE_NAME'    => 'Browser',
-    
+
         #default action name
         'DEFAULT_ACTION_NAME'    => 'index',
-    
+
         #BASE PATH: the root path in the file system (usually the document root)
         'BASE_PATH'                => __DIR__.DIRECTORY_SEPARATOR ,
-    
+
         #BASE URL (usually the domain root)
         'BASE_URL'                => ROOT_URL . 'ltiOutcomeUi/',
     ),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -31,6 +31,6 @@ class Updater extends \common_ext_ExtensionUpdater
      */
     public function update($initialVersion)
     {
-        $this->setVersion('0.1.0');
+        $this->setVersion('0.1.1');
     }
 }


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/MS-35

We need to use lti outcome UI in manual scoring to display the item response to scorer.

Frontend component expects the item response object from the backend to be like this:

![Screenshot 2020-01-10 at 18 03 40](https://user-images.githubusercontent.com/4357095/72171639-b0782000-33d3-11ea-9cf0-e42c5ab13c11.png)

But, in this extension, the backend controller is sending the item response to frontend in a slightly different structure:

![Screenshot 2020-01-10 at 18 04 18](https://user-images.githubusercontent.com/4357095/72171680-c1289600-33d3-11ea-8816-b0e79493b832.png)

For some reason the response is sent inside an array hence the frontend component can not render it.

So, to fix the issue I am sending only the current item response from the array and not the array itself. 
