### PR TITLE
[MS-35] Possibility to hide action bars in item previewer

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
     'label' => 'LTI Result Tool Provider',
     'description' => 'The LTI Result Tool Provider allows third party applications to view results created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '0.1.1',
+    'version' => '0.2.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoLti' => '>=6.3.3',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -31,6 +31,6 @@ class Updater extends \common_ext_ExtensionUpdater
      */
     public function update($initialVersion)
     {
-        $this->setVersion('0.1.1');
+        $this->setVersion('0.2.0');
     }
 }

--- a/views/js/controller/ItemResultPreviewer/itemResultPreviewer.js
+++ b/views/js/controller/ItemResultPreviewer/itemResultPreviewer.js
@@ -25,7 +25,8 @@ define([
 
             previewerFactory(type, uri, state, {
                 readOnly: true,
-                fullPage: true
+                fullPage: true,
+                hideActionBars: true,
             });
         }
     };


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/MS-35
 
Introduce new option for item preview test runner to be able to hide action bars based on this option
  
#### How to test
- Try to preview an item using /ltiOutcomeUi/ItemResultPreviewer/preview action
- Check that there is no action bars on the UI


#### Dependencies
   
Companion PR :
 - [x] https://github.com/oat-sa/extension-tao-testqti-previewer/pull/42