### PR TITLE
Make previewer use preview language logic from taoQtiTestPreviewer ext

### DIFF
--- a/controller/ItemResultPreviewer.php
+++ b/controller/ItemResultPreviewer.php
@@ -19,7 +19,6 @@
 
 namespace oat\ltiOutcomeUi\controller;
 
-use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\log\LoggerAwareTrait;
 use oat\taoDelivery\model\execution\ServiceProxy;
@@ -30,7 +29,6 @@ use oat\taoOutcomeUi\model\ResultsService;
 use oat\taoOutcomeUi\model\ResultsViewerService;
 use oat\taoQtiTestPreviewer\models\ItemPreviewer;
 use oat\taoQtiTestPreviewer\models\PreviewLanguageService;
-use oat\taoResultServer\models\classes\ResultServerService;
 use \core_kernel_classes_Resource;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 

--- a/manifest.php
+++ b/manifest.php
@@ -25,12 +25,12 @@ return array(
     'label' => 'LTI Result Tool Provider',
     'description' => 'The LTI Result Tool Provider allows third party applications to view results created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '0.2.0',
+    'version' => '0.3.0',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoLti' => '>=6.3.3',
         'taoOutcomeUi' => '>=5.12.0',
-        'taoQtiTestPreviewer' => '>=0.2.0'
+        'taoQtiTestPreviewer' => '>=2.11.0'
     ),
     'models' => [],
     'install' => [


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/MS-107

PR for `taoQtiTestPreviewer` has description but regarding preview in TAO Platform. Main logic is the same but here it is related to external LTI preview requests

How to test:
In current implementation it can be tested using manual scoring.
1. Set up scoring stack environment https://github.com/oat-sa/scoring-docker-stack, create scorer and scorer assignment to score particular category
2. Create and publish delivery with external scored items with category assigned to scorer
3. Create test taker with interface language different from English
4. Make sure param `lock_data_language` in your tao/config/generis/UserLanguageService.conf.php is set to `true`
4. Give the test by that test taker, login into manual scoring by scorer, you should see the successfully loaded item previews. If you set `lock_data_language` to false, preview won't be available, service will respond with error




