### PR TITLE
Fix/MS-771/restrict max highlighter counter to 99

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
     'label' => 'LTI Result Tool Provider',
     'description' => 'The LTI Result Tool Provider allows third party applications to view results created in Tao',
     'license' => 'GPL-2.0',
-    'version' => '0.10.1',
+    'version' => '0.10.2',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'taoLti' => '>=6.3.3',

--- a/views/js/previewer/plugins/content/scoringHighlighter.js
+++ b/views/js/previewer/plugins/content/scoringHighlighter.js
@@ -107,9 +107,9 @@ define([
             function getAllRanges(selection) {
                 const allRanges = [];
 
-                    for (let i = 0; i < selection.rangeCount; i++) {
-                        allRanges.push(selection.getRangeAt(i));
-                    }
+                for (let i = 0; i < selection.rangeCount; i++) {
+                    allRanges.push(selection.getRangeAt(i));
+                }
                 return allRanges;
             }
 
@@ -235,7 +235,7 @@ define([
                         const count = colorCounter[colorName];
                         const $colorCounter = $(`button.${colorName} .counter`, this.$highlighterTray);
 
-                        $colorCounter.text(count);
+                        $colorCounter.text(count > 99 ? 99 : count);
                     }
                 });
             };


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/MS-771
**Description:** The maximum highlight count for a given color is 99. If reached, new highlights can still be added, but the counter does not increase anymore.
**How to test:** 
- Login as scorer
- Highlight more than 99 text sections