### PR TITLE
PHP 8 migration

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,27 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-version: [ '7.4', '8.0', '8.1' ]
+        include:
+          - php-version: '8.1'
+            coverage: true
+
+    steps:
+      - name: CI
+        uses: oat-sa/tao-extension-ci-action@v1
+        with:
+          php: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}

--- a/composer.json
+++ b/composer.json
@@ -1,75 +1,75 @@
 {
     "name": "oat-sa/extension-lti-outcomeui",
-    "description" : "Extension to manage LTI result provider for TAO",
-    "type" : "tao-extension",
-    "authors" : [
-		{
-		"name" : "Open Assessment Technologies S.A.",
-		"homepage" : "http://www.taotesting.com"
-		},
-		{
-		"name": "Jérôme Bogaerts",
-		"role": "Developer"
-		},
-		{
-		"name": "Joel Bout",
-		"role": "Developer"
-		},
-		{
-		"name": "Bertrand Chevrier",
-		"role": "Developer"
-		},
-		{
-		"name": "Lionel Lecaque",
-		"role": "Developer"
-		},
-		{
-		"name": "Patrick Plichart",
-		"role": "Developer"
-		},
-		{
-		"name": "Dieter Raber",
-		"role": "Developer"
-		},
-		{
-		"name": "Somsack Sipasseuth",
-		"role": "Developer"
-		},
-		{
-		"name": "Camille Moyon",
-		"role": "Developer"
-		}
-	],
-	"support": {
-		"forum": "https://forum.taocloud.org/",
-		"issues": "https://forum.taocloud.org/",
-		"docs": "https://hub.taocloud.org/"
-	},
-	"keywords" : [
-		"tao",
-		"oat",
-		"QTI",
-		"computer-based-assessment"
-	],
-	"homepage" : "http://www.taotesting.com",
-	"license" : [
-		"GPL-2.0-only"
-	],
-    "extra" : {
-    	"tao-extension-name" : "ltiOutcomeUi"
+    "description": "Extension to manage LTI result provider for TAO",
+    "type": "tao-extension",
+    "authors": [
+        {
+            "name": "Open Assessment Technologies S.A.",
+            "homepage": "http://www.taotesting.com"
+        },
+        {
+            "name": "Jérôme Bogaerts",
+            "role": "Developer"
+        },
+        {
+            "name": "Joel Bout",
+            "role": "Developer"
+        },
+        {
+            "name": "Bertrand Chevrier",
+            "role": "Developer"
+        },
+        {
+            "name": "Lionel Lecaque",
+            "role": "Developer"
+        },
+        {
+            "name": "Patrick Plichart",
+            "role": "Developer"
+        },
+        {
+            "name": "Dieter Raber",
+            "role": "Developer"
+        },
+        {
+            "name": "Somsack Sipasseuth",
+            "role": "Developer"
+        },
+        {
+            "name": "Camille Moyon",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "forum": "https://forum.taocloud.org/",
+        "issues": "https://forum.taocloud.org/",
+        "docs": "https://hub.taocloud.org/"
     },
-	"autoload" : {
-		"psr-4": {
-			"oat\\ltiOutcomeUi\\" :""
-		}
+    "keywords": [
+        "tao",
+        "oat",
+        "QTI",
+        "computer-based-assessment"
+    ],
+    "homepage": "http://www.taotesting.com",
+    "license": [
+        "GPL-2.0-only"
+    ],
+    "extra": {
+        "tao-extension-name": "ltiOutcomeUi"
     },
-    "minimum-stability" : "dev",
+    "autoload": {
+        "psr-4": {
+            "oat\\ltiOutcomeUi\\": ""
+        }
+    },
+    "minimum-stability": "dev",
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-		"oat-sa/generis" : ">=14.0.0",
-		"oat-sa/extension-tao-delivery" : ">=15.0.0",
-		"oat-sa/extension-tao-lti" : ">=12.0.0",
-		"oat-sa/extension-tao-outcomeui" : ">=10.0.0",
-		"oat-sa/extension-tao-testqti-previewer" : ">=3.0.0"
-	}
+        "oat-sa/generis": ">=15.22",
+        "oat-sa/extension-tao-delivery": ">=15.0.0",
+        "oat-sa/extension-tao-lti": ">=12.0.0",
+        "oat-sa/extension-tao-outcomeui": ">=10.0.0",
+        "oat-sa/extension-tao-testqti-previewer": ">=3.0.0"
+    }
 }


### PR DESCRIPTION
[ADF-1097](https://oat-sa.atlassian.net/browse/ADF-1097)
[ADF-1087](https://oat-sa.atlassian.net/browse/ADF-1087)
[ADF-1105](https://oat-sa.atlassian.net/browse/ADF-1105)

## Goal
Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.