### PR TITLE
fix: fixed parsing responses from the outcome ui with the new structu…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
 		"oat-sa/generis" : ">=14.0.0",
 		"oat-sa/extension-tao-delivery" : ">=15.0.0",
 		"oat-sa/extension-tao-lti" : ">=12.0.0",
-		"oat-sa/extension-tao-outcomeui" : ">=10.0.0",
+		"oat-sa/extension-tao-outcomeui" : ">=11.0.0",
 		"oat-sa/extension-tao-testqti-previewer" : ">=3.0.0"
 	}
 }

--- a/controller/ItemResultPreviewer.php
+++ b/controller/ItemResultPreviewer.php
@@ -150,9 +150,7 @@ class ItemResultPreviewer extends ToolModule
         $variable = $this->getItemVariable($delivery, $resultIdentifier, $itemDefinition);
         if (isset($variable['uri'])) {
             $responses = ResponseVariableFormatter::formatStructuredVariablesToItemState([$variable]);
-            if (isset($responses[$variable['uri']])) {
-                return $responses[$variable['uri']];
-            }
+            return current($responses);
         }
 
         return null;


### PR DESCRIPTION
During https://github.com/oat-sa/extension-tao-outcomeui/pull/399 it was a breaking change in how we generate the structure of item states.

In the lti-outcomeui we need to update a way how to parse it.