### PR TITLE
Fix/parsing responses for lti preview

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "oat-sa/generis": ">=15.22",
         "oat-sa/extension-tao-delivery": ">=15.0.0",
         "oat-sa/extension-tao-lti": ">=12.0.0",
-        "oat-sa/extension-tao-outcomeui": ">=10.0.0",
+        "oat-sa/extension-tao-outcomeui": ">=11.0.0",
         "oat-sa/extension-tao-testqti-previewer": ">=3.0.0"
     }
 }

--- a/controller/ItemResultPreviewer.php
+++ b/controller/ItemResultPreviewer.php
@@ -153,9 +153,7 @@ class ItemResultPreviewer extends ToolModule
         $variable = $this->getItemVariable($delivery, $resultIdentifier, $itemDefinition);
         if (isset($variable['uri'])) {
             $responses = $this->getResultVariableStructureHandler()->format([$variable]);
-            if (isset($responses[$variable['uri']])) {
-                return $responses[$variable['uri']];
-            }
+            return current($responses);
         }
 
         return null;


### PR DESCRIPTION
During https://github.com/oat-sa/extension-tao-outcomeui/pull/399 it was a breaking change in how we generate the structure of item states.

https://github.com/oat-sa/extension-tao-outcomeui/pull/399/files#diff-37485dd39184a5f39c01bbb83c568a0cbd337e119e4717e34af7aa1d34c9a3fcL176

In the lti-outcomeui we need to update a way how to parse it.

How to test:

1. Pass a test
2. Using LTI Preview `tiOutcomeUi/ItemResultPreviewer/launch?resultId=YOUR ID&itemRef=YOUR ITEM REF ID` open the LTI preview 